### PR TITLE
PHP 8.4 compatibility fixes

### DIFF
--- a/src/Api/OrdersApi.php
+++ b/src/Api/OrdersApi.php
@@ -89,10 +89,10 @@ class OrdersApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
-        $hostIndex = 0
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
+        ?int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/src/Api/SessionsApi.php
+++ b/src/Api/SessionsApi.php
@@ -89,10 +89,10 @@ class SessionsApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
-        $hostIndex = 0
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
+        ?int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -314,7 +314,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('attention', $data ?? [], null);
         $this->setIfExists('city', $data ?? [], null);

--- a/src/Model/AssetUrls.php
+++ b/src/Model/AssetUrls.php
@@ -248,7 +248,7 @@ class AssetUrls implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('descriptive', $data ?? [], null);
         $this->setIfExists('standard', $data ?? [], null);

--- a/src/Model/Attachment.php
+++ b/src/Model/Attachment.php
@@ -248,7 +248,7 @@ class Attachment implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('body', $data ?? [], null);
         $this->setIfExists('content_type', $data ?? [], null);

--- a/src/Model/AuthorizedPaymentMethod.php
+++ b/src/Model/AuthorizedPaymentMethod.php
@@ -289,7 +289,7 @@ class AuthorizedPaymentMethod implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('number_of_days', $data ?? [], null);
         $this->setIfExists('number_of_installments', $data ?? [], null);

--- a/src/Model/CreateOrderRequest.php
+++ b/src/Model/CreateOrderRequest.php
@@ -359,7 +359,7 @@ class CreateOrderRequest implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('authorization_token', $data ?? [], null);
         $this->setIfExists('auto_capture', $data ?? [], false);

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -323,7 +323,7 @@ class Customer implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('date_of_birth', $data ?? [], null);
         $this->setIfExists('gender', $data ?? [], null);

--- a/src/Model/CustomerRead.php
+++ b/src/Model/CustomerRead.php
@@ -311,7 +311,7 @@ class CustomerRead implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('date_of_birth', $data ?? [], null);
         $this->setIfExists('gender', $data ?? [], null);

--- a/src/Model/CustomerReadCreateToken.php
+++ b/src/Model/CustomerReadCreateToken.php
@@ -248,7 +248,7 @@ class CustomerReadCreateToken implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('date_of_birth', $data ?? [], null);
         $this->setIfExists('gender', $data ?? [], null);

--- a/src/Model/CustomerTokenCreationRequest.php
+++ b/src/Model/CustomerTokenCreationRequest.php
@@ -291,7 +291,7 @@ class CustomerTokenCreationRequest implements ModelInterface, ArrayAccess, \Json
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('customer', $data ?? [], null);

--- a/src/Model/CustomerTokenCreationResponse.php
+++ b/src/Model/CustomerTokenCreationResponse.php
@@ -266,7 +266,7 @@ class CustomerTokenCreationResponse implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('customer', $data ?? [], null);

--- a/src/Model/ErrorV2.php
+++ b/src/Model/ErrorV2.php
@@ -254,7 +254,7 @@ class ErrorV2 implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/MerchantSession.php
+++ b/src/Model/MerchantSession.php
@@ -254,7 +254,7 @@ class MerchantSession implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('client_token', $data ?? [], null);
         $this->setIfExists('payment_method_categories', $data ?? [], null);

--- a/src/Model/MerchantUrls.php
+++ b/src/Model/MerchantUrls.php
@@ -260,7 +260,7 @@ class MerchantUrls implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('confirmation', $data ?? [], null);
         $this->setIfExists('notification', $data ?? [], null);

--- a/src/Model/Options.php
+++ b/src/Model/Options.php
@@ -266,7 +266,7 @@ class Options implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('color_border', $data ?? [], null);
         $this->setIfExists('color_border_selected', $data ?? [], null);

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -260,7 +260,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('authorized_payment_method', $data ?? [], null);
         $this->setIfExists('fraud_status', $data ?? [], null);

--- a/src/Model/OrderLine.php
+++ b/src/Model/OrderLine.php
@@ -326,7 +326,7 @@ class OrderLine implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('image_url', $data ?? [], null);
         $this->setIfExists('merchant_data', $data ?? [], null);

--- a/src/Model/PaymentMethodCategory.php
+++ b/src/Model/PaymentMethodCategory.php
@@ -254,7 +254,7 @@ class PaymentMethodCategory implements ModelInterface, ArrayAccess, \JsonSeriali
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('asset_urls', $data ?? [], null);
         $this->setIfExists('identifier', $data ?? [], null);

--- a/src/Model/ProductIdentifiers.php
+++ b/src/Model/ProductIdentifiers.php
@@ -272,7 +272,7 @@ class ProductIdentifiers implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('brand', $data ?? [], null);
         $this->setIfExists('category_path', $data ?? [], null);

--- a/src/Model/Session.php
+++ b/src/Model/Session.php
@@ -429,7 +429,7 @@ class Session implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('acquiring_channel', $data ?? [], null);
         $this->setIfExists('attachment', $data ?? [], null);

--- a/src/Model/SessionCreate.php
+++ b/src/Model/SessionCreate.php
@@ -429,7 +429,7 @@ class SessionCreate implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('acquiring_channel', $data ?? [], null);
         $this->setIfExists('attachment', $data ?? [], null);

--- a/src/Model/SessionRead.php
+++ b/src/Model/SessionRead.php
@@ -429,7 +429,7 @@ class SessionRead implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('acquiring_channel', $data ?? [], null);
         $this->setIfExists('attachment', $data ?? [], null);

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -273,7 +273,7 @@ class Subscription implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('name', $data ?? [], null);
         $this->setIfExists('interval', $data ?? [], null);


### PR DESCRIPTION
Fixes PHP warning "Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead."